### PR TITLE
docs: Fix a few typos

### DIFF
--- a/ext/nanovg/stb_image.h
+++ b/ext/nanovg/stb_image.h
@@ -5268,7 +5268,7 @@ static stbi_uc *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int 
       //     Else if n is 128, noop.
       // Endloop
 
-      // The RLE-compressed data is preceeded by a 2-byte data count for each row in the data,
+      // The RLE-compressed data is preceded by a 2-byte data count for each row in the data,
       // which we're going to just skip.
       stbi__skip(s, h * channelCount * 2 );
 

--- a/ext/qm-dsp/ext/clapack/src/ieeeck.c
+++ b/ext/qm-dsp/ext/clapack/src/ieeeck.c
@@ -39,7 +39,7 @@ integer ieeeck_(integer *ispec, real *zero, real *one)
 /*  ========= */
 
 /*  ISPEC   (input) INTEGER */
-/*          Specifies whether to test just for inifinity arithmetic */
+/*          Specifies whether to test just for infinity arithmetic */
 /*          or whether to test for infinity and NaN arithmetic. */
 /*          = 0: Verify infinity arithmetic only. */
 /*          = 1: Verify infinity and NaN arithmetic. */

--- a/src/actions/actions.c
+++ b/src/actions/actions.c
@@ -3659,7 +3659,7 @@ DEFINE_SIMPLE (
 
 /**
  * Activate \ref setting if given, otherwise create
- * a defeault setting from the descriptor.
+ * a default setting from the descriptor.
  */
 static void
 activate_plugin_setting (

--- a/src/gui/backend/arranger_selections.c
+++ b/src/gui/backend/arranger_selections.c
@@ -2490,7 +2490,7 @@ arranger_selections_paste_to_pos (
   arranger_selections_get_start_pos (
     clone_sel, &first_obj_pos, F_NOT_GLOBAL);
 
-  /* if timeline selecctions */
+  /* if timeline selections */
   if (self->type == ARRANGER_SELECTIONS_TYPE_TIMELINE)
     {
       TimelineSelections * ts =


### PR DESCRIPTION
There are small typos in:
- ext/nanovg/stb_image.h
- ext/qm-dsp/ext/clapack/src/ieeeck.c
- src/actions/actions.c
- src/gui/backend/arranger_selections.c

Fixes:
- Should read `selections` rather than `selecctions`.
- Should read `preceded` rather than `preceeded`.
- Should read `infinity` rather than `inifinity`.
- Should read `default` rather than `defeault`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md