### PR TITLE
MidiTest: add unit tests for midi_get_meta_event_data()

### DIFF
--- a/src/utils/midi.h
+++ b/src/utils/midi.h
@@ -412,8 +412,6 @@ std::string
 midi_get_meta_event_type_name (midi_byte_t type);
 
 /**
- * FIXME NOT TESTED
- *
  * Saves a pointer to the event data in @ref data
  * and returns the size.
  *

--- a/tests/unit/utils/midi_test.cpp
+++ b/tests/unit/utils/midi_test.cpp
@@ -94,3 +94,162 @@ TEST (MidiTest, CombinedValues)
   std::array<midi_byte_t, 3> buf{ MIDI_CH1_PITCH_WHEEL_RANGE, 120, 95 };
   EXPECT_EQ (midi_get_14_bit_value (buf), 12280);
 }
+
+TEST (MidiTest, MetaEventDetection)
+{
+  std::vector<midi_byte_t> meta{ 0xFF, 0x01, 0x03, 'a', 'b', 'c' };
+  EXPECT_TRUE (midi_is_meta_event (meta));
+  EXPECT_FALSE (midi_is_short_msg (meta));
+
+  std::vector<midi_byte_t> sysex{ 0xF0, 0x01, 0x02 };
+  EXPECT_TRUE (midi_is_sysex (sysex));
+
+  std::array<midi_byte_t, 3> note_on{ 0x90, 0x40, 0x64 };
+  EXPECT_FALSE (midi_is_meta_event (note_on));
+  EXPECT_TRUE (midi_is_short_msg (note_on));
+
+  std::vector<midi_byte_t> too_short_1{ 0xFF };
+  EXPECT_FALSE (midi_is_meta_event (too_short_1));
+
+  std::vector<midi_byte_t> too_short_2{ 0xFF, 0x01 };
+  EXPECT_FALSE (midi_is_meta_event (too_short_2));
+}
+
+TEST (MidiTest, MetaEventTypeChecks)
+{
+  std::vector<midi_byte_t> set_tempo{ 0xFF, 0x51, 0x03, 0x07, 0xA1, 0x20 };
+  EXPECT_TRUE (midi_is_meta_event_of_type (set_tempo, 0x51));
+  EXPECT_FALSE (midi_is_meta_event_of_type (set_tempo, 0x58));
+  EXPECT_EQ (midi_get_meta_event_type (set_tempo), 0x51);
+
+  std::vector<midi_byte_t> end_of_track{ 0xFF, 0x2F, 0x00 };
+  EXPECT_EQ (midi_get_meta_event_type (end_of_track), 0x2F);
+}
+
+TEST (MidiTest, MetaEventDataSimpleSingleByteLength)
+{
+  std::vector<midi_byte_t> msg{ 0xFF, 0x01, 0x03, 'A', 'B', 'C' };
+  const midi_byte_t * data = nullptr;
+  size_t len = midi_get_meta_event_data (&data, msg.data (), msg.size ());
+  EXPECT_EQ (len, 3u);
+  ASSERT_NE (data, nullptr);
+  EXPECT_EQ (data[0], 'A');
+  EXPECT_EQ (data[1], 'B');
+  EXPECT_EQ (data[2], 'C');
+}
+
+TEST (MidiTest, MetaEventDataZeroLength)
+{
+  std::vector<midi_byte_t> msg{ 0xFF, 0x2F, 0x00 };
+  const midi_byte_t * data = nullptr;
+  size_t              len = midi_get_meta_event_data (&data, msg.data (), msg.size ());
+  EXPECT_EQ (len, 0u);
+}
+
+TEST (MidiTest, MetaEventDataSetTempo)
+{
+  std::vector<midi_byte_t> msg{ 0xFF, 0x51, 0x03, 0x07, 0xA1, 0x20 };
+  const midi_byte_t * data = nullptr;
+  size_t              len = midi_get_meta_event_data (&data, msg.data (), msg.size ());
+  EXPECT_EQ (len, 3u);
+  ASSERT_NE (data, nullptr);
+  EXPECT_EQ (data[0], 0x07);
+  EXPECT_EQ (data[1], 0xA1);
+  EXPECT_EQ (data[2], 0x20);
+}
+
+TEST (MidiTest, MetaEventDataTimeSignature)
+{
+  std::vector<midi_byte_t> msg{ 0xFF, 0x58, 0x04, 0x04, 0x02, 0x18, 0x08 };
+  const midi_byte_t * data = nullptr;
+  size_t              len = midi_get_meta_event_data (&data, msg.data (), msg.size ());
+  EXPECT_EQ (len, 4u);
+  ASSERT_NE (data, nullptr);
+  EXPECT_EQ (data[0], 0x04);
+  EXPECT_EQ (data[1], 0x02);
+}
+
+TEST (MidiTest, MetaEventDataKeySignature)
+{
+  std::vector<midi_byte_t> msg{ 0xFF, 0x59, 0x02, 0x00, 0x00 };
+  const midi_byte_t * data = nullptr;
+  size_t              len = midi_get_meta_event_data (&data, msg.data (), msg.size ());
+  EXPECT_EQ (len, 2u);
+  ASSERT_NE (data, nullptr);
+  EXPECT_EQ (data[0], 0x00);
+  EXPECT_EQ (data[1], 0x00);
+}
+
+TEST (MidiTest, MetaEventDataTwoByteVLQ)
+{
+  std::vector<midi_byte_t> msg (4 + 128, 0);
+  msg[0] = 0xFF;
+  msg[1] = 0x01;
+  msg[2] = 0x81;
+  msg[3] = 0x00;
+  const midi_byte_t * data = nullptr;
+  size_t len = midi_get_meta_event_data (&data, msg.data (), msg.size ());
+  EXPECT_EQ (len, 128u);
+  ASSERT_NE (data, nullptr);
+  EXPECT_EQ (data, &msg[4]);
+}
+
+TEST (MidiTest, MetaEventDataThreeByteVLQ)
+{
+  const size_t        content_len = 16384;
+  std::vector<midi_byte_t> msg (5 + content_len, 0);
+  msg[0] = 0xFF;
+  msg[1] = 0x01;
+  msg[2] = 0x81;
+  msg[3] = 0x80;
+  msg[4] = 0x00;
+  const midi_byte_t * data = nullptr;
+  size_t              len = midi_get_meta_event_data (&data, msg.data (), msg.size ());
+  EXPECT_EQ (len, content_len);
+  ASSERT_NE (data, nullptr);
+  EXPECT_EQ (data, &msg[5]);
+}
+
+TEST (MidiTest, MetaEventDataMalformedTooShort)
+{
+  std::vector<midi_byte_t> msg{ 0xFF, 0x01, 0x03 };
+  const midi_byte_t * data = nullptr;
+  size_t              len = midi_get_meta_event_data (&data, msg.data (), msg.size ());
+  EXPECT_EQ (len, 0u);
+}
+
+TEST (MidiTest, MetaEventDataMalformedVLQNoTerminator)
+{
+  std::vector<midi_byte_t> msg{ 0xFF, 0x01, 0x80, 0x80, 0x80 };
+  const midi_byte_t * data = nullptr;
+  size_t              len = midi_get_meta_event_data (&data, msg.data (), msg.size ());
+  EXPECT_EQ (len, 0u);
+}
+
+TEST (MidiTest, MetaEventDataMalformedVLQExceedsMsgSize)
+{
+  std::vector<midi_byte_t> msg{ 0xFF, 0x01, 0x80 };
+  const midi_byte_t * data = nullptr;
+  size_t              len = midi_get_meta_event_data (&data, msg.data (), msg.size ());
+  EXPECT_EQ (len, 0u);
+}
+
+TEST (MidiTest, MetaEventDataMalformedContentTruncated)
+{
+  std::vector<midi_byte_t> msg{ 0xFF, 0x01, 0x0A, 'a', 'b' };
+  const midi_byte_t * data = nullptr;
+  size_t              len = midi_get_meta_event_data (&data, msg.data (), msg.size ());
+  EXPECT_EQ (len, 0u);
+}
+
+TEST (MidiTest, MetaEventTypeNameLookup)
+{
+  EXPECT_EQ (midi_get_meta_event_type_name (0x00), "Sequence number");
+  EXPECT_EQ (midi_get_meta_event_type_name (0x01), "Text");
+  EXPECT_EQ (midi_get_meta_event_type_name (0x03), "Track name");
+  EXPECT_EQ (midi_get_meta_event_type_name (0x2F), "End of track");
+  EXPECT_EQ (midi_get_meta_event_type_name (0x51), "Set tempo");
+  EXPECT_EQ (midi_get_meta_event_type_name (0x58), "Time signature");
+  EXPECT_EQ (midi_get_meta_event_type_name (0x59), "Key signature");
+  EXPECT_EQ (midi_get_meta_event_type_name (0x7F), "Sequencer specific");
+}


### PR DESCRIPTION
## Summary

- Add 14 unit tests covering `midi_get_meta_event_data()` and related meta event utilities (`midi_is_meta_event`, `midi_is_sysex`, `midi_is_short_msg`, `midi_is_meta_event_of_type`, `midi_get_meta_event_type`, `midi_get_meta_event_type_name`)
- Test cases cover: simple single-byte VLQ, zero-length events (End of Track), realistic Set Tempo / Time Signature / Key Signature events, multi-byte VLQ (2-byte and 3-byte encodings), and malformed input edge cases (too short, unterminated VLQ, VLQ exceeding buffer, truncated content)
- Remove `FIXME NOT TESTED` comment from `midi_get_meta_event_data()` in `src/utils/midi.h`

## Testing

- All new tests follow existing patterns in `tests/unit/utils/midi_test.cpp` (gtest, bare `TEST()` macros, `using namespace zrythm::utils::midi`)
- No build system changes required — `midi_test.cpp` is already in the `zrythm_utils_unit_tests` target

## Files Changed

- `tests/unit/utils/midi_test.cpp` — 14 new test cases appended
- `src/utils/midi.h` — removed `FIXME NOT TESTED` comment