### PR TITLE
CarlaNativePlugin: fix resourceDir heap memory leak

### DIFF
--- a/src/plugins/carla_native_plugin.cpp
+++ b/src/plugins/carla_native_plugin.cpp
@@ -1244,8 +1244,8 @@ CarlaNativePlugin::instantiate_impl (bool loading, bool use_state_file)
   auto         dir =
     fs::path (carla_filename).parent_path ().parent_path ().parent_path ();
   auto res_dir = dir / "share" / "carla" / "resources";
-  // FIXME leak
-  native_host_descriptor_.resourceDir = g_strdup (res_dir);
+  resource_dir_str_ = res_dir.string ();
+  native_host_descriptor_.resourceDir = resource_dir_str_.c_str ();
 
   native_host_descriptor_.get_buffer_size = host_get_buffer_size;
   native_host_descriptor_.get_sample_rate = host_get_sample_rate;

--- a/src/plugins/carla_native_plugin.h
+++ b/src/plugins/carla_native_plugin.h
@@ -195,6 +195,8 @@ public:
   CarlaHostHandle host_handle_ = nullptr;
 
   NativeTimeInfo time_info_ = {};
+
+  std::string resource_dir_str_;
 #endif
 
   /** Plugin ID inside carla engine. */


### PR DESCRIPTION
## Summary

- Fix memory leak where `g_strdup()` allocates heap memory for `native_host_descriptor_.resourceDir` but it is never freed in the destructor or `close()` method
- Replace `g_strdup()` with a `std::string` member (`resource_dir_str_`) that manages its own lifetime automatically, and point `resourceDir` at its `c_str()`
- Remove `// FIXME leak` comment

## Details

The leak occurs at `src/plugins/carla_native_plugin.cpp:1247` — `g_strdup(res_dir)` allocates via GLib's allocator and stores the result in a raw `const char*` on the `NativeHostDescriptor` struct. The destructor calls `close()` which frees the host handle and plugin descriptor but never calls `g_free()` on this pointer.

The same file already uses the correct `g_free()` pattern at line 1007 for a similar allocation — this was simply an oversight.

The `std::string` approach is preferred because it eliminates the leak entirely through RAII, avoiding the need to add manual `g_free()` calls in `close()`.

## Files Changed

- `src/plugins/carla_native_plugin.h` — add `std::string resource_dir_str_;` member
- `src/plugins/carla_native_plugin.cpp` — replace `g_strdup()` with `resource_dir_str_` assignment